### PR TITLE
fix(cli): Document default value for transaction tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Options:
   --mwm <number>              Minimum weight magnitude to use for attaching the transaction to the tangle (default: "14")
   --seed <string>             81 Tryte seed used to generate addresses
   --address-index <number>    Index number used to generate addresses 0
-  --transaction-tag <string>  Tag to apply to the Tangle transaction
+  --transaction-tag <string>  Tag to apply to the Tangle transaction (default: "GITHUB9RELEASE")
   --comment <string>          An optional comment to include in the Tangle transaction payload
   --explorer-url <string>     Url of the explorer to use for exploration link (default: "https://utils.iota.org/transaction/:hash")
   --help                      Display help
 
-  
+
 Example: gh-tangle-release --github-token a4d936470cb3d66f5434f787c2500bde9764f --owner my-org --repository my-repo --release-tag v1.0.1 --seed AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
   ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ program
         "14")
     .option("--seed <string>", chalk.yellowBright("81 Tryte seed used to generate addresses"))
     .option("--address-index <number>", chalk.yellowBright("Index number used to generate addresses", "0"))
-    .option("--transaction-tag <string>", chalk.yellowBright("Tag to apply to the Tangle transaction"))
+    .option("--transaction-tag <string>", chalk.yellowBright("Tag to apply to the Tangle transaction"), "GITHUB9RELEASE")
     .option("--comment <string>",
         chalk.yellowBright("An optional comment to include in the Tangle transaction payload"))
     .option("--explorer-url <string>", chalk.yellowBright("Url of the explorer to use for exploration link"),


### PR DESCRIPTION
The default value for transaction tags is `GITHUB9RELEASE`, but this is not documented in the CLI help message﻿
