### PR TITLE
fix(core): Allow tags with length of 27

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -39,7 +39,7 @@ export function sanitizeInput(config: IPartialConfig): IConfig {
     if (!/[9A-Z]/.test(config.transactionTag)) {
         throw new Error("The transaction tag option must be 27 trytes [A-Z9] or less");
     }
-    if (config.transactionTag.length >= 27) {
+    if (config.transactionTag.length > 27) {
         throw new Error(`The transaction tag option must be 27 trytes [A-Z9] or less, it is ${
             config.transactionTag.length}`);
     }


### PR DESCRIPTION
The validation for transaction tags prohibited tags with lengths >=27, when tags with a length of 27 trytes are valid. This PR prohibits tags with a length >27﻿
